### PR TITLE
Refer to the ZIO ecosystem documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # Summary
 
 # Documentation
-[ZIO Mock Microsite](https://zio.github.io/zio-mock/)
+[ZIO Ecosystem Documentation](https://zio.dev/resources/ecosystem/officials/zio-mock)
 
 # Contributing
 [Documentation for contributors](https://zio.github.io/zio-mock/docs/about/about_contributing)

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -16,3 +16,5 @@ Start by adding `zio-mock` as a dependency to your project:
     println(s"""```""")
 ```
 
+The documentation for zio-mock is currently available on [zio.dev](https://zio.dev/resources/ecosystem/officials/zio-mock).
+


### PR DESCRIPTION
It's pretty confusing that the documentation for zio-mock is available at zio.dev and not on the microsite.

I've added a link back to the proper page in the microsite.
I've also included this link as the main documentation link in the README.