### PR TITLE
Replace deprecated `unsafeCompat` call

### DIFF
--- a/mock/shared/src/main/scala-2/zio/mock/MockableMacro.scala
+++ b/mock/shared/src/main/scala-2/zio/mock/MockableMacro.scala
@@ -231,7 +231,7 @@ private[mock] object MockableMacro {
       }
 
       def wrapInUnsafe(tree: Tree): Tree =
-        q"""_root_.zio.Unsafe.unsafeCompat { __unsafeVal =>
+        q"""_root_.zio.Unsafe.unsafe { __unsafeVal =>
               implicit val __unsafeImplicit = __unsafeVal
               $tree
            }


### PR DESCRIPTION
This will prevent compiler warnings when mocking stream based services and the like.